### PR TITLE
fix: Corrigido o problema com modprobe

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,12 +8,13 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: ubuntu-iac-rke 
+  - name: ubuntu-iac-rke
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
       - /var/run/docker.sock:/var/run/docker.sock
+      - /lib/modules/:/lib/modules:ro
     privileged: true
     pre_build_image: true
 provisioner:

--- a/molecule/default/tests/test_rke.py
+++ b/molecule/default/tests/test_rke.py
@@ -13,7 +13,7 @@ def test_hosts_file(host):
     for name in (
      "/usr/bin/kubectl",
      "/etc/docker/daemon.json",
-     "/etc/sysctl.d/k8s.conf",
+     "/etc/sysctl.d/20-net-bridge.conf",
     ):
 
         f = host.file(name)
@@ -62,8 +62,8 @@ def test_if_container_is_removed(host):
 
 def test_if_ssh__and_k8s_config_is_ok(host):
 
-    conteudo = ['AllowTcpForwarding yes','net.bridge.bridge-nf-call-iptables']
-    path = ['/etc/ssh/ssh_config','/etc/sysctl.d/k8s.conf']
+    conteudo = ['AllowTcpForwarding yes','net.bridge.bridge-nf-call-iptables', 'net.bridge.bridge-nf-call-ip6tables']
+    path = ['/etc/ssh/ssh_config','/etc/sysctl.d/20-net-bridge.conf', '/etc/sysctl.d/20-net-bridge.conf']
 
     for i, name in enumerate(path):
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,14 +9,21 @@
     state: present
     update_cache: yes
 
-- name: Configuração do iptables
-  sysctl:
-    name: net.bridge.bridge-nf-call-iptables
-    value: "1"
-    sysctl_file: "/etc/sysctl.d/k8s.conf"
-    sysctl_set: yes
+- name: Instalação do module BR_Netfilter
+  community.general.modprobe:
+    name: br_netfilter
     state: present
+
+- name: " Configuração do iptables para BR_netfilter"
+  ansible.posix.sysctl:
+    name: "{{ item }}"
+    sysctl_set: yes
+    value: "1"
     reload: yes
+    sysctl_file: /etc/sysctl.d/20-net-bridge.conf
+  loop:
+    - "net.bridge.bridge-nf-call-ip6tables"
+    - "net.bridge.bridge-nf-call-iptables"
 
 - name: Adicionando chaves gpg do Docker
   apt_key:


### PR DESCRIPTION
    Durante a execução do packer foi identificado que o systctl não
    estava funcionando.

    Para a correção do issue, na role do ansible foi incluido a task
    de habilitar o modulo br_netfiler utilizando modprobe.

    O molecule necessitou algumas configurações extras, incluindo um
    bind de volume /lib/modules no container, para permitir o module
    se carregado. Feito ajuste também no test infra para buscar os
    novos parametros do bridge.

    Revisado por:
    - Sebawebber
    - Danilo Rocha
    - Luiz Aoqui
    - ramonboorges
    - Brunareisalm
    - Juan maia
    - robertoromeu
    Refs #4

# Titulo

<!-- Por favor descreva seu pull request aqui. -->

- [ ] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [ ] Dê um titulo que expresse o objetivo do PR
- [ ] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [ ] Descreva o objetivo do PR
- [ ] Inclua links relevantes para a sua modificação/sugestão/correção
- [ ] Descreva um passo-a-passo para testar o seu PR

## Issue

<!-- Link da issue -->

## Objetivo

<!-- Descrição do objetivo -->

## Referências

<!-- Links relevantes -->

## Como testar

<!-- Passo a passo -->

<!--
Marque um `x` dentro de [ ] para os itens que você forneceu informação
Para modificar este template no seu repositório, basta criar o arquivo .github/pull_request_template.md nele.
-->
